### PR TITLE
Fix loginizer fatal error and increase WP memory

### DIFF
--- a/wp-config.php
+++ b/wp-config.php
@@ -89,6 +89,7 @@ $table_prefix = 'wpkh_';
  */
 define( 'WP_DEBUG', true );
 define( 'WP_DEBUG_LOG', true );
+define( 'WP_MEMORY_LIMIT', '256M' );
 
 /* Add any custom values between this line and the "stop editing" line. */
 

--- a/wp-content/plugins/loginizer-security/init.php
+++ b/wp-content/plugins/loginizer-security/init.php
@@ -142,7 +142,8 @@ $site_name';
 	
 	// Checksum Settings
 	$options = get_option('loginizer_checksums');
-	$loginizer['disable_checksum'] = empty($options['disable_checksum']) ? '' : $options['disable_checksum'];
+       // Disable checksum scans by default to avoid long execution times
+       $loginizer['disable_checksum'] = empty($options['disable_checksum']) ? '1' : $options['disable_checksum'];
 	$loginizer['checksum_time'] = empty($options['checksum_time']) ? '' : $options['checksum_time'];
 	$loginizer['checksum_frequency'] = empty($options['checksum_frequency']) ? 7 : $options['checksum_frequency'];
 	$loginizer['no_checksum_email'] = empty($options['no_checksum_email']) ? '' : $options['no_checksum_email'];


### PR DESCRIPTION
## Summary
- avoid long-running checksum scans in `loginizer-security` by disabling them by default
- bump WordPress memory limit to help heavy plugins

## Testing
- `php -l wp-content/plugins/loginizer-security/init.php`
- `php -l wp-config.php`


------
https://chatgpt.com/codex/tasks/task_e_6877c83fda20832091c0ea15515a7924